### PR TITLE
🐞 fix: the record should be sent according to the r_use_base64 configuration

### DIFF
--- a/nonebot_plugin_resolver2/exception.py
+++ b/nonebot_plugin_resolver2/exception.py
@@ -32,8 +32,7 @@ def handle_exception(matcher: type[Matcher], error_message: str | None = None):
                 return await func(*args, **kwargs)
             except (ParseException, DownloadException) as e:
                 # logger.warning(f"{matcher.module_name}: {e}")
-                msg = error_message or str(e)
-                await matcher.finish(msg, reply_message=True)
+                await matcher.finish(error_message or str(e))
 
         return wrapper
 

--- a/nonebot_plugin_resolver2/matchers/bilibili.py
+++ b/nonebot_plugin_resolver2/matchers/bilibili.py
@@ -27,7 +27,7 @@ from ..parsers.bilibili import (
     parse_video_info,
 )
 from .filter import is_not_in_disabled_groups
-from .helper import get_file_seg, get_img_seg, get_video_seg, send_segments
+from .helper import get_file_seg, get_img_seg, get_record_seg, get_video_seg, send_segments
 from .preprocess import ExtractText, Keyword, r_keywords
 
 bilibili = on_message(
@@ -230,7 +230,7 @@ async def _(bot: Bot, event: MessageEvent, args: Message = CommandArg()):
         await download_file_by_stream(video_info.audio_url, file_name=audio_name, ext_headers=HEADERS)
 
     # 发送音频
-    await bili_music.send(MessageSegment.record(audio_path))
+    await bili_music.send(get_record_seg(audio_path))
     # 上传音频
     if NEED_UPLOAD:
         await bili_music.send(get_file_seg(audio_path))

--- a/nonebot_plugin_resolver2/matchers/helper.py
+++ b/nonebot_plugin_resolver2/matchers/helper.py
@@ -64,6 +64,19 @@ def get_img_seg(img_path: Path) -> MessageSegment:
     return MessageSegment.image(file)
 
 
+def get_record_seg(audio_path: Path) -> MessageSegment:
+    """获取语音 Seg
+
+    Args:
+        audio_path (Path): 语音路径
+
+    Returns:
+        MessageSegment: 语音 Seg
+    """
+    file = audio_path.read_bytes() if USE_BASE64 else audio_path
+    return MessageSegment.record(file)
+
+
 def get_video_seg(video_path: Path) -> MessageSegment:
     """获取视频 Seg
 

--- a/nonebot_plugin_resolver2/matchers/kugou.py
+++ b/nonebot_plugin_resolver2/matchers/kugou.py
@@ -1,7 +1,6 @@
 import re
 
 from nonebot import logger, on_message
-from nonebot.adapters.onebot.v11 import MessageSegment
 
 from ..config import NEED_UPLOAD, NICKNAME
 from ..download import download_audio, download_img
@@ -9,7 +8,7 @@ from ..download.utils import keep_zh_en_num
 from ..exception import handle_exception
 from ..parsers.kugou import KuGou
 from .filter import is_not_in_disabled_groups
-from .helper import get_file_seg, get_img_seg
+from .helper import get_file_seg, get_img_seg, get_record_seg
 from .preprocess import ExtractText, r_keywords
 
 kugou = on_message(rule=is_not_in_disabled_groups & r_keywords("kugou.com"))
@@ -35,7 +34,7 @@ async def _(text: str = ExtractText()):
 
     audio_path = await download_audio(url=video_info.music_url)
     # 发送语音
-    await kugou.send(MessageSegment.record(audio_path))
+    await kugou.send(get_record_seg(audio_path))
     # 发送群文件
     if NEED_UPLOAD:
         filename = f"{keep_zh_en_num(title_author_name)}.flac"

--- a/nonebot_plugin_resolver2/matchers/ytb.py
+++ b/nonebot_plugin_resolver2/matchers/ytb.py
@@ -2,7 +2,7 @@ from pathlib import Path
 import re
 
 from nonebot import logger, on_keyword
-from nonebot.adapters.onebot.v11 import Bot, Message, MessageEvent, MessageSegment
+from nonebot.adapters.onebot.v11 import Bot, Message, MessageEvent
 from nonebot.params import Arg
 from nonebot.rule import Rule
 from nonebot.typing import T_State
@@ -12,7 +12,7 @@ from ..download.utils import keep_zh_en_num
 from ..download.ytdlp import get_video_info, ytdlp_download_audio, ytdlp_download_video
 from ..exception import handle_exception
 from .filter import is_not_in_disabled_groups
-from .helper import get_file_seg, get_video_seg
+from .helper import get_file_seg, get_record_seg, get_video_seg
 
 ytb = on_keyword(keywords={"youtube.com", "youtu.be"}, rule=Rule(is_not_in_disabled_groups))
 
@@ -61,7 +61,7 @@ async def _(bot: Bot, event: MessageEvent, state: T_State, type: Message = Arg()
     if video_path:
         await ytb.send(get_video_seg(video_path))
     elif audio_path:
-        await ytb.send(MessageSegment.record(audio_path))
+        await ytb.send(get_record_seg(audio_path))
         if NEED_UPLOAD:
             file_name = f"{keep_zh_en_num(title)}.flac"
             await ytb.send(get_file_seg(audio_path, file_name))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nonebot-plugin-resolver2"
-version = "1.8.1"
+version = "1.8.2"
 description = "NoneBot2 链接分享解析器自动解析, BV号/链接/小程序/卡片 | B站/抖音/网易云/微博/小红书/youtube/tiktok/twitter/acfun"
 authors = [{ "name" = "fllesser", "email" = "fllessive@gmail.com" }]
 urls = { Repository = "https://github.com/fllesser/nonebot-plugin-resolver2" }


### PR DESCRIPTION
- Added a new helper function `get_record_seg` to create audio message segments, improving code clarity and reusability.
- Updated matchers (Bilibili, Kugou, NCM, YTB) to utilize `get_record_seg` for sending audio segments, enhancing consistency across the codebase.
- Simplified error handling in the `handle_exception` function by removing unnecessary parameters in the `finish` method call.