### PR TITLE
🔧 fix: Correct proxy parameter typo and enhance image downloading functionality

### DIFF
--- a/nonebot_plugin_resolver2/download/__init__.py
+++ b/nonebot_plugin_resolver2/download/__init__.py
@@ -182,6 +182,7 @@ async def download_imgs_without_raise(
     Args:
         urls (list[str]): urls
         ext_headers (dict[str, str] | None, optional): ext headers. Defaults to None.
+        proxy (str | None, optional): proxy url. Defaults to None.
 
     Returns:
         list[Path]: image file paths

--- a/nonebot_plugin_resolver2/download/__init__.py
+++ b/nonebot_plugin_resolver2/download/__init__.py
@@ -156,7 +156,7 @@ async def download_img(
     Args:
         url (str): url
         img_name (str, optional): image name. Defaults to None.
-        proxy (str, optional): proxry url. Defaults to None.
+        proxy (str, optional): proxy url. Defaults to None.
         ext_headers (dict[str, str], optional): ext headers. Defaults to None.
 
     Returns:
@@ -171,7 +171,12 @@ async def download_img(
     return await download_file_by_stream(url, file_name=img_name, proxy=proxy, ext_headers=ext_headers)
 
 
-async def download_imgs_without_raise(urls: list[str], ext_headers: dict[str, str] | None = None) -> list[Path]:
+async def download_imgs_without_raise(
+    urls: list[str],
+    *,
+    ext_headers: dict[str, str] | None = None,
+    proxy: str | None = None,
+) -> list[Path]:
     """download images without raise
 
     Args:
@@ -182,7 +187,7 @@ async def download_imgs_without_raise(urls: list[str], ext_headers: dict[str, st
         list[Path]: image file paths
     """
     paths_or_errs = await asyncio.gather(
-        *[download_img(url, ext_headers=ext_headers) for url in urls], return_exceptions=True
+        *[download_img(url, ext_headers=ext_headers, proxy=proxy) for url in urls], return_exceptions=True
     )
     return [p for p in paths_or_errs if isinstance(p, Path)]
 

--- a/nonebot_plugin_resolver2/matchers/twitter.py
+++ b/nonebot_plugin_resolver2/matchers/twitter.py
@@ -32,11 +32,11 @@ async def _(event: MessageEvent):
     video_url, pic_urls = await parse_x_url(x_url)
 
     if video_url:
-        video_path = await download_video(url=video_url, proxy=PROXY)
+        video_path = await download_video(video_url, proxy=PROXY)
         await twitter.send(get_video_seg(video_path))
 
     if pic_urls:
-        img_paths = await download_imgs_without_raise(urls=pic_urls, proxy=PROXY)
+        img_paths = await download_imgs_without_raise(pic_urls, proxy=PROXY)
         await send_segments([get_img_seg(img_path) for img_path in img_paths])
 
 

--- a/nonebot_plugin_resolver2/matchers/twitter.py
+++ b/nonebot_plugin_resolver2/matchers/twitter.py
@@ -1,4 +1,3 @@
-import asyncio
 import re
 from typing import Any
 
@@ -9,7 +8,7 @@ from nonebot.rule import Rule
 
 from ..config import NICKNAME, PROXY
 from ..constant import COMMON_HEADER
-from ..download import download_img, download_video
+from ..download import download_imgs_without_raise, download_video
 from ..exception import ParseException, handle_exception
 from .filter import is_not_in_disabled_groups
 from .helper import get_img_seg, get_video_seg, send_segments
@@ -37,8 +36,7 @@ async def _(event: MessageEvent):
         await twitter.send(get_video_seg(video_path))
 
     if pic_urls:
-        tasks = [download_img(url=pic_url, proxy=PROXY) for pic_url in pic_urls]
-        img_paths = await asyncio.gather(*tasks)
+        img_paths = await download_imgs_without_raise(urls=pic_urls, proxy=PROXY)
         await send_segments([get_img_seg(img_path) for img_path in img_paths])
 
 

--- a/tests/test_x.py
+++ b/tests/test_x.py
@@ -6,7 +6,7 @@ import pytest
 
 @pytest.mark.asyncio
 async def test_x():
-    from nonebot_plugin_resolver2.download import download_img, download_video
+    from nonebot_plugin_resolver2.download import download_imgs_without_raise, download_video
     from nonebot_plugin_resolver2.matchers.twitter import parse_x_url
 
     urls = [
@@ -25,8 +25,7 @@ async def test_x():
             logger.success(f"{url} | 视频解析并下载成功")
         if pic_urls:
             logger.info(f"{url} | 解析为图片: {pic_urls}")
-            tasks = [download_img(url=pic_url) for pic_url in pic_urls]
-            img_paths = await asyncio.gather(*tasks)
+            img_paths = await download_imgs_without_raise(pic_urls)
             assert len(img_paths) == len(pic_urls)
             for img_path in img_paths:
                 assert img_path.exists()


### PR DESCRIPTION
- Fixed a typo in the `download_img` function's docstring.
- Updated `download_imgs_without_raise` to accept a proxy parameter, improving flexibility in image downloading from multiple URLs.

## Summary by Sourcery

Enable proxy support for batch image downloads, update Twitter matcher to leverage enhanced downloader, and correct a typo in the download_img docstring

Bug Fixes:
- Corrected typo in download_img docstring parameter description

Enhancements:
- Add proxy parameter to download_imgs_without_raise for flexible image downloading
- Update Twitter matcher to use download_imgs_without_raise with proxy instead of individual download tasks