### PR TITLE
🎈 perf: Update exception handling in matchers to use current_matcher

### DIFF
--- a/nonebot_plugin_resolver2/exception.py
+++ b/nonebot_plugin_resolver2/exception.py
@@ -1,7 +1,7 @@
 from collections.abc import Callable
 from functools import wraps
 
-from nonebot.matcher import Matcher
+from nonebot.internal.matcher import current_matcher
 
 
 class DownloadException(Exception):
@@ -16,7 +16,7 @@ class ParseException(Exception):
     pass
 
 
-def handle_exception(matcher: type[Matcher], error_message: str | None = None):
+def handle_exception(error_message: str | None = None):
     """处理 matcher 中的 DownloadException 和 ParseException 异常的装饰器
 
     Args:
@@ -30,6 +30,7 @@ def handle_exception(matcher: type[Matcher], error_message: str | None = None):
             try:
                 return await func(*args, **kwargs)
             except (ParseException, DownloadException) as e:
+                matcher = current_matcher.get()
                 # logger.warning(f"{matcher.module_name}: {e}")
                 await matcher.finish(error_message or str(e))
 

--- a/nonebot_plugin_resolver2/matchers/acfun.py
+++ b/nonebot_plugin_resolver2/matchers/acfun.py
@@ -16,7 +16,7 @@ parser = AcfunParser()
 
 
 @acfun.handle()
-@handle_exception(acfun)
+@handle_exception()
 async def _(event: MessageEvent) -> None:
     message: str = event.message.extract_plain_text().strip()
     matched = re.search(r"(?:ac=|/ac)(\d+)", message)

--- a/nonebot_plugin_resolver2/matchers/bilibili.py
+++ b/nonebot_plugin_resolver2/matchers/bilibili.py
@@ -43,7 +43,7 @@ parser = BilibiliParser()
 
 
 @bilibili.handle()
-@handle_exception(bilibili)
+@handle_exception()
 async def _(text: str = ExtractText(), keyword: str = Keyword()):
     pub_prefix = f"{NICKNAME}解析 | 哔哩哔哩 - "
     matched = PATTERNS[keyword].search(text)

--- a/nonebot_plugin_resolver2/matchers/douyin.py
+++ b/nonebot_plugin_resolver2/matchers/douyin.py
@@ -19,7 +19,7 @@ douyin_parser = DouyinParser()
 
 
 @douyin.handle()
-@handle_exception(douyin)
+@handle_exception()
 async def _(event: MessageEvent):
     # 消息
     msg: str = event.message.extract_plain_text().strip()

--- a/nonebot_plugin_resolver2/matchers/kuaishou.py
+++ b/nonebot_plugin_resolver2/matchers/kuaishou.py
@@ -30,7 +30,7 @@ PATTERNS = {
 
 
 @kuaishou.handle()
-@handle_exception(kuaishou)
+@handle_exception()
 async def _(text: str = ExtractText(), keyword: str = Keyword()):
     """处理快手视频链接"""
     matched = PATTERNS[keyword].search(text)

--- a/nonebot_plugin_resolver2/matchers/kugou.py
+++ b/nonebot_plugin_resolver2/matchers/kugou.py
@@ -16,7 +16,7 @@ parser = KuGouParser()
 
 
 @kugou.handle()
-@handle_exception(kugou)
+@handle_exception()
 async def _(text: str = ExtractText()):
     pub_prefix = f"{NICKNAME}解析 | 酷狗音乐 - "
     # https://t1.kugou.com/song.html?id=1hfw6baEmV3

--- a/nonebot_plugin_resolver2/matchers/ncm.py
+++ b/nonebot_plugin_resolver2/matchers/ncm.py
@@ -15,7 +15,7 @@ parser = NCMParser()
 
 
 @ncm.handle()
-@handle_exception(ncm)
+@handle_exception()
 async def _(text: str = ExtractText(), keyword: str = Keyword()):
     result = await parser.parse_ncm(text)
     detail = f"{NICKNAME}解析 | 网易云 - {result.title}-{result.author}"

--- a/nonebot_plugin_resolver2/matchers/tiktok.py
+++ b/nonebot_plugin_resolver2/matchers/tiktok.py
@@ -15,7 +15,7 @@ tiktok = on_keyword(keywords={"tiktok.com"}, rule=Rule(is_not_in_disabled_groups
 
 
 @tiktok.handle()
-@handle_exception(tiktok)
+@handle_exception()
 async def _(event: MessageEvent):
     # 消息
     message: str = event.message.extract_plain_text().strip()

--- a/nonebot_plugin_resolver2/matchers/twitter.py
+++ b/nonebot_plugin_resolver2/matchers/twitter.py
@@ -17,7 +17,7 @@ twitter = on_keyword(keywords={"x.com"}, rule=Rule(is_not_in_disabled_groups))
 
 
 @twitter.handle()
-@handle_exception(twitter)
+@handle_exception()
 async def _(event: MessageEvent):
     msg: str = event.message.extract_plain_text().strip()
     pattern = r"https?:\/\/x.com\/[0-9-a-zA-Z_]{1,20}\/status\/([0-9]+)"

--- a/nonebot_plugin_resolver2/matchers/weibo.py
+++ b/nonebot_plugin_resolver2/matchers/weibo.py
@@ -15,7 +15,7 @@ weibo = on_keyword(keywords={"weibo.com", "m.weibo.cn"}, rule=Rule(is_not_in_dis
 
 
 @weibo.handle()
-@handle_exception(weibo)
+@handle_exception()
 async def _(event: MessageEvent):
     message = event.message.extract_plain_text().strip()
     video_info = await weibo_parser.parse_share_url(message)

--- a/nonebot_plugin_resolver2/matchers/xiaohongshu.py
+++ b/nonebot_plugin_resolver2/matchers/xiaohongshu.py
@@ -17,7 +17,7 @@ xhs_parser = XiaoHongShuParser()
 
 
 @xiaohongshu.handle()
-@handle_exception(xiaohongshu)
+@handle_exception()
 async def _(text: str = ExtractText()):
     pattern = r"(http:|https:)\/\/(xhslink|(www\.)xiaohongshu).com\/[A-Za-z\d._?%&+\-=\/#@]*"
     matched = re.search(pattern, text)

--- a/nonebot_plugin_resolver2/matchers/ytb.py
+++ b/nonebot_plugin_resolver2/matchers/ytb.py
@@ -19,7 +19,7 @@ ytb = on_keyword(keywords={"youtube.com", "youtu.be"}, rule=Rule(is_not_in_disab
 
 
 @ytb.handle()
-@handle_exception(ytb)
+@handle_exception()
 async def _(event: MessageEvent, state: T_State):
     message = event.message.extract_plain_text().strip()
     pattern = (


### PR DESCRIPTION
- Removed matcher parameter from handle_exception decorator in multiple matchers.
- Updated exception handling to utilize current_matcher for improved context during error handling.

## Summary by Sourcery

Refactor exception handling to use current matcher context instead of passing matcher objects

Enhancements:
- Remove matcher parameter from handle_exception decorator and retrieve the matcher via current_matcher.get()
- Update all plugin matchers to invoke handle_exception() without explicit matcher arguments