### PR TITLE
🐞 fix: 修复 B 站无音频流视频解析

### DIFF
--- a/nonebot_plugin_resolver2/matchers/bilibili.py
+++ b/nonebot_plugin_resolver2/matchers/bilibili.py
@@ -212,6 +212,7 @@ async def _(text: str = ExtractText(), keyword: str = Keyword()):
 
 
 @bili_music.handle()
+@handle_exception()
 async def _(bot: Bot, event: MessageEvent, args: Message = CommandArg()):
     text = args.extract_plain_text().strip()
     matched = re.match(r"^(BV[1-9a-zA-Z]{10})(?:\s)?(\d{1,3})?$", text)

--- a/nonebot_plugin_resolver2/matchers/bilibili.py
+++ b/nonebot_plugin_resolver2/matchers/bilibili.py
@@ -193,7 +193,9 @@ async def _(text: str = ExtractText(), keyword: str = Keyword()):
             )
             await merge_av(v_path=v_path, a_path=a_path, output_path=video_path)
         else:
-            video_path = await download_video(video_info.video_url, video_name=file_name, ext_headers=parser.headers)
+            video_path = await download_video(
+                video_info.video_url, video_name=f"{file_name}.mp4", ext_headers=parser.headers
+            )
 
     # 发送视频
     try:

--- a/nonebot_plugin_resolver2/parsers/bilibili.py
+++ b/nonebot_plugin_resolver2/parsers/bilibili.py
@@ -286,12 +286,13 @@ class BilibiliParser:
         detecter = VideoDownloadURLDataDetecter(download_url_data)
         streams = detecter.detect_best_streams(video_max_quality=VideoQuality._1080P, no_dolby_video=True, no_hdr=True)
         video_stream = streams[0]
-        assert isinstance(video_stream, VideoStreamDownloadURL)
+        if not isinstance(video_stream, VideoStreamDownloadURL):
+            raise ParseException("未找到可下载的视频流")
+        logger.debug(f"视频流质量: {video_stream.video_quality.name}")
         audio_stream = streams[1]
-        assert isinstance(audio_stream, AudioStreamDownloadURL)
-        if video_stream is None or audio_stream is None:
-            raise ParseException("未找到可下载的视频流或音频流")
-        logger.debug(f"视频流质量 {video_stream.video_quality.name}, 音频流质量 {audio_stream.audio_quality.name}")
+        if not isinstance(audio_stream, AudioStreamDownloadURL):
+            return video_stream.url, ""
+        logger.debug(f"音频流质量: {audio_stream.audio_quality.name}")
         return video_stream.url, audio_stream.url
 
     def _extra_bili_info(self, video_info: dict[str, Any]) -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ test = [
   "nonebot2[fastapi]>=2.4.2,<3.0.0",
   "nonebug>=0.3.7,<1.0.0",
   "pytest-xdist>=3.6.1,<4.0.0",
-  "pytest-asyncio>=0.26.0,<1.0.0",
+  "pytest-asyncio>=1.0.0,<1.1.0",
 ]
 
 

--- a/tests/test_bilibili.py
+++ b/tests/test_bilibili.py
@@ -7,11 +7,11 @@ import pytest
 
 @pytest.mark.asyncio
 async def test_bilibili_live():
-    logger.info("开始解析B站直播 https://live.bilibili.com/23585383")
+    logger.info("开始解析B站直播 https://live.bilibili.com/6")
     from nonebot_plugin_resolver2.parsers import BilibiliParser
 
-    # https://live.bilibili.com/23585383
-    room_id = 23585383
+    # https://live.bilibili.com/6
+    room_id = 6
     bilibili_parser = BilibiliParser()
     title, cover, _ = await bilibili_parser.parse_live(room_id)
     assert title

--- a/tests/test_bilibili_need_ck.py
+++ b/tests/test_bilibili_need_ck.py
@@ -68,3 +68,12 @@ async def test_encode_h264_video():
     video_h264_path = await encode_video_to_h264(video_path)
     assert not video_path.exists()
     assert video_h264_path.exists()
+
+
+async def test_no_audio_video():
+    from nonebot_plugin_resolver2.parsers import BilibiliParser
+
+    bilibili_parser = BilibiliParser()
+
+    video_url, _ = await bilibili_parser.parse_video_download_url(bvid="BV1gRjMziELt")
+    logger.debug(f"video_url: {video_url}")

--- a/uv.lock
+++ b/uv.lock
@@ -919,7 +919,7 @@ wheels = [
 
 [[package]]
 name = "nonebot-plugin-resolver2"
-version = "1.8.8"
+version = "1.9.1"
 source = { virtual = "." }
 dependencies = [
     { name = "aiofiles" },
@@ -968,7 +968,7 @@ dev = [
 test = [
     { name = "nonebot2", extras = ["fastapi"], specifier = ">=2.4.2,<3.0.0" },
     { name = "nonebug", specifier = ">=0.3.7,<1.0.0" },
-    { name = "pytest-asyncio", specifier = ">=0.26.0,<1.0.0" },
+    { name = "pytest-asyncio", specifier = ">=1.0.0,<1.1.0" },
     { name = "pytest-xdist", specifier = ">=3.6.1,<4.0.0" },
 ]
 
@@ -1367,14 +1367,14 @@ wheels = [
 
 [[package]]
 name = "pytest-asyncio"
-version = "0.26.0"
+version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pytest" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8e/c4/453c52c659521066969523e87d85d54139bbd17b78f09532fb8eb8cdb58e/pytest_asyncio-0.26.0.tar.gz", hash = "sha256:c4df2a697648241ff39e7f0e4a73050b03f123f760673956cf0d72a4990e312f", size = 54156, upload-time = "2025-03-25T06:22:28.883Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d0/d4/14f53324cb1a6381bef29d698987625d80052bb33932d8e7cbf9b337b17c/pytest_asyncio-1.0.0.tar.gz", hash = "sha256:d15463d13f4456e1ead2594520216b225a16f781e144f8fdf6c5bb4667c48b3f", size = 46960, upload-time = "2025-05-26T04:54:40.484Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/20/7f/338843f449ace853647ace35870874f69a764d251872ed1b4de9f234822c/pytest_asyncio-0.26.0-py3-none-any.whl", hash = "sha256:7b51ed894f4fbea1340262bdae5135797ebbe21d8638978e35d31c6d19f72fb0", size = 19694, upload-time = "2025-03-25T06:22:27.807Z" },
+    { url = "https://files.pythonhosted.org/packages/30/05/ce271016e351fddc8399e546f6e23761967ee09c8c568bbfbecb0c150171/pytest_asyncio-1.0.0-py3-none-any.whl", hash = "sha256:4f024da9f1ef945e680dc68610b52550e36590a67fd31bb3b4943979a1f90ef3", size = 15976, upload-time = "2025-05-26T04:54:39.035Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
fixes #131

## Summary by Sourcery

Fix Bilibili resolver to properly handle videos lacking audio streams, ensuring fallback download and stream validation

Bug Fixes:
- Download solo video when no audio stream is available instead of merging empty tracks
- Raise ParseException when audio stream is missing during music command parsing
- Validate video and audio stream types and error out if missing

Enhancements:
- Add debug logs for resolved video and audio quality
- Apply exception handler decorator to music matcher

Build:
- Bump pytest-asyncio dependency to >=1.0.0,<1.1.0

Tests:
- Add test for parsing Bilibili videos without audio streams
- Update live-stream test case URL