### PR TITLE
✨ feat: 优化B站视频解析时长限制提示

### DIFF
--- a/nonebot_plugin_resolver2/matchers/bilibili.py
+++ b/nonebot_plugin_resolver2/matchers/bilibili.py
@@ -167,7 +167,7 @@ async def _(text: str = ExtractText(), keyword: str = Keyword()):
         video_info.ai_summary,
     ]
     await send_segments(segs)
-    
+
     if video_info.video_duration > DURATION_MAXIMUM:
         await bilibili.send(
             f"⚠️ 当前视频时长 {video_info.video_duration // 60} 分钟, "

--- a/nonebot_plugin_resolver2/matchers/bilibili.py
+++ b/nonebot_plugin_resolver2/matchers/bilibili.py
@@ -166,12 +166,13 @@ async def _(text: str = ExtractText(), keyword: str = Keyword()):
         video_info.display_info,
         video_info.ai_summary,
     ]
+    await send_segments(segs)
+    
     if video_info.video_duration > DURATION_MAXIMUM:
-        segs.append(
+        await bilibili.send(
             f"⚠️ 当前视频时长 {video_info.video_duration // 60} 分钟, "
             f"超过管理员设置的最长时间 {DURATION_MAXIMUM // 60} 分钟!"
         )
-    await send_segments(segs)
 
     if video_info.video_duration > DURATION_MAXIMUM:
         logger.info(f"video duration > {DURATION_MAXIMUM}, ignore download")


### PR DESCRIPTION
![Screenshot_com tencent tim-edit](https://github.com/user-attachments/assets/c347c57d-bc7f-4daf-9963-0a6a00a09de9)
效果如图所示

## Summary by Sourcery

Reorder the dispatch of video info segments and optimize the duration limit warning by sending it directly, removing the redundant segment send call.

Enhancements:
- Send parsed video info segments before performing the duration limit check
- Issue duration limit warning with a direct channel send instead of appending to the segment list
- Remove the redundant send_segments call after the warning