### PR TITLE
fix: enhance bilibili credential handling

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -6,7 +6,7 @@ NICKNAME='["BOT"]'
 # 使用当前工作目录作为数据存储目录，以下数据目录配置项默认值将会对应变更
 LOCALSTORE_USE_CWD=true
 
-#r_bili_ck="SESSDATA=jdkcnsjkxbdj"
+r_bili_ck="SESSDATA=jdkcnsjkxbdj"
 r_bili_video_codes='["avc","av01"]'
 r_xhs_ck="a=a;b=b;c=c"
 r_ytb_ck="a=a;b=b;c=c"

--- a/src/nonebot_plugin_resolver2/parsers/bilibili.py
+++ b/src/nonebot_plugin_resolver2/parsers/bilibili.py
@@ -57,6 +57,7 @@ class BilibiliParser:
 
         if not await self._credential.check_valid():
             logger.warning("哔哩哔哩 cookie 已过期, 请重新配置哔哩哔哩 cookie")
+            self._credential = None
             return None
 
         if await self._credential.check_refresh():

--- a/src/nonebot_plugin_resolver2/parsers/bilibili.py
+++ b/src/nonebot_plugin_resolver2/parsers/bilibili.py
@@ -2,11 +2,12 @@ from dataclasses import dataclass
 import re
 from typing import Any
 
-from bilibili_api import HEADERS, Credential
+from bilibili_api import HEADERS, Credential, request_settings, select_client
 from bilibili_api.video import Video
 from nonebot import logger
 
 from ..config import rconfig
+from ..cookie import ck2dict
 from ..exception import ParseException
 
 
@@ -31,11 +32,6 @@ class BilibiliParser:
     def _init_credential(self):
         """初始化 bilibili api"""
 
-        from bilibili_api import request_settings, select_client
-
-        from ..config import rconfig
-        from ..cookie import ck2dict
-
         # 选择客户端
         select_client("curl_cffi")
         # 模仿浏览器
@@ -50,6 +46,8 @@ class BilibiliParser:
 
     @property
     async def credential(self) -> Credential | None:
+        """获取哔哩哔哩登录凭证"""
+
         if not self._credential:
             self._init_credential()
             if not self._credential:


### PR DESCRIPTION
- Removed redundant imports from the _init_credential method.
- Added a docstring to the credential property for clarity on its purpose.

## Summary by Sourcery

Clean up the Bilibili parser by removing unused imports, documenting the credential property, and ensuring expired cookies clear the stored credential

Bug Fixes:
- Reset the cached credential to None when the Bilibili cookie has expired

Enhancements:
- Remove redundant imports in the _init_credential method
- Add a docstring to the credential property for clarity