### PR TITLE
🎈 perf: enhance pytest workflow for bilibili, kuaishou, standardize HTTP client timeout

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -38,8 +38,14 @@ jobs:
       - name: setup-pytest
         uses: ./.github/actions/setup-pytest
       
-      - name: pytest
-        run: uv run pytest tests/test_bilibili.py
+      - name: opus, read, live tests
+        run: |
+          uv run pytest tests/test_bilibili.py
+      - name: no audio video, favlist, video tests
+        run: |
+          uv run pytest tests/test_bilibili_need_ck.py::test_no_audio_video
+          uv run pytest tests/test_bilibili_need_ck.py::test_bilibili_favlist
+          uv run pytest tests/test_bilibili_need_ck.py::test_bilibili_video
 
 
   weibo-test:
@@ -100,13 +106,13 @@ jobs:
       - name: pytest
         run: uv run pytest tests/test_xhs.py
   
-  # kuaishou-test:
-  #   needs: plugin-load
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #     - name: setup-pytest
-  #       uses: ./.github/actions/setup-pytest
+  kuaishou-test:
+    needs: plugin-load
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: setup-pytest
+        uses: ./.github/actions/setup-pytest
       
-  #     - name: pytest
-  #       run: uv run pytest tests/test_kuaishou.py
+      - name: pytest
+        run: uv run pytest tests/test_kuaishou.py::test_parse

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nonebot-plugin-resolver2"
-version = "1.10.1"
+version = "1.10.2"
 description = "NoneBot2 链接分享解析器自动解析, BV号/链接/小程序/卡片 | B站/抖音/网易云/微博/小红书/youtube/tiktok/twitter/acfun"
 authors = [{ "name" = "fllesser", "email" = "fllessive@gmail.com" }]
 urls = { Repository = "https://github.com/fllesser/nonebot-plugin-resolver2" }

--- a/src/nonebot_plugin_resolver2/constant.py
+++ b/src/nonebot_plugin_resolver2/constant.py
@@ -1,5 +1,7 @@
 from typing import Final
 
+import httpx
+
 COMMON_HEADER: Final[dict[str, str]] = {
     "User-Agent": "Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) "
     "Chrome/55.0.2883.87 UBrowser/6.2.4098.3 Safari/537.36"
@@ -21,3 +23,7 @@ VIDEO_MAX_MB: Final[int] = 100
 
 # 解析列表文件名
 DISABLED_GROUPS: Final[str] = "disable_group_list.json"
+
+COMMON_TIMEOUT: Final[httpx.Timeout] = httpx.Timeout(connect=15.0, read=20.0, write=10.0, pool=10.0)
+
+DOWNLOAD_TIMEOUT: Final[httpx.Timeout] = httpx.Timeout(connect=10.0, read=240.0, write=10.0, pool=10.0)

--- a/src/nonebot_plugin_resolver2/matchers/tiktok.py
+++ b/src/nonebot_plugin_resolver2/matchers/tiktok.py
@@ -6,6 +6,7 @@ from nonebot.adapters.onebot.v11 import MessageEvent
 from nonebot.rule import Rule
 
 from ..config import NICKNAME
+from ..constant import COMMON_TIMEOUT
 from ..download.ytdlp import get_video_info, ytdlp_download_video
 from ..exception import handle_exception
 from .filter import is_not_in_disabled_groups
@@ -29,7 +30,7 @@ async def _(event: MessageEvent):
 
     # 如果 prefix 是 vt 或 vm，则需要重定向
     if prefix == "vt" or prefix == "vm":
-        async with httpx.AsyncClient(follow_redirects=True) as client:
+        async with httpx.AsyncClient(follow_redirects=True, timeout=COMMON_TIMEOUT) as client:
             response = await client.get(url)
             url = response.headers.get("Location")
 

--- a/src/nonebot_plugin_resolver2/matchers/twitter.py
+++ b/src/nonebot_plugin_resolver2/matchers/twitter.py
@@ -57,7 +57,7 @@ async def parse_x_url(x_url: str) -> tuple[str, list[str]]:
             **COMMON_HEADER,
         }
         data = {"q": url, "lang": "zh-cn"}
-        async with httpx.AsyncClient(headers=headers) as client:
+        async with httpx.AsyncClient(headers=headers, timeout=20) as client:
             url = "https://xdown.app/api/ajaxSearch"
             response = await client.post(url, data=data)
             return response.json()

--- a/src/nonebot_plugin_resolver2/matchers/twitter.py
+++ b/src/nonebot_plugin_resolver2/matchers/twitter.py
@@ -7,7 +7,7 @@ from nonebot.adapters.onebot.v11 import MessageEvent
 from nonebot.rule import Rule
 
 from ..config import NICKNAME
-from ..constant import COMMON_HEADER
+from ..constant import COMMON_HEADER, COMMON_TIMEOUT
 from ..download import download_imgs_without_raise, download_video
 from ..exception import ParseException, handle_exception
 from .filter import is_not_in_disabled_groups
@@ -57,7 +57,7 @@ async def parse_x_url(x_url: str) -> tuple[str, list[str]]:
             **COMMON_HEADER,
         }
         data = {"q": url, "lang": "zh-cn"}
-        async with httpx.AsyncClient(headers=headers, timeout=20) as client:
+        async with httpx.AsyncClient(headers=headers, timeout=COMMON_TIMEOUT) as client:
             url = "https://xdown.app/api/ajaxSearch"
             response = await client.post(url, data=data)
             return response.json()

--- a/src/nonebot_plugin_resolver2/parsers/douyin.py
+++ b/src/nonebot_plugin_resolver2/parsers/douyin.py
@@ -5,6 +5,7 @@ from typing import Any
 import httpx
 from nonebot import logger
 
+from ..constant import COMMON_TIMEOUT
 from ..exception import ParseException
 from .data import ANDROID_HEADER, IOS_HEADER, ParseResult
 from .utils import get_redirect_url
@@ -52,7 +53,7 @@ class DouyinParser:
         raise ParseException("作品已删除，或资源直链获取失败, 请稍后再试")
 
     async def parse_video(self, url: str) -> ParseResult:
-        async with httpx.AsyncClient(headers=self.ios_headers, verify=False) as client:
+        async with httpx.AsyncClient(headers=self.ios_headers, verify=False, timeout=COMMON_TIMEOUT) as client:
             response = await client.get(url)
             response.raise_for_status()
             text = response.text

--- a/src/nonebot_plugin_resolver2/parsers/kuaishou.py
+++ b/src/nonebot_plugin_resolver2/parsers/kuaishou.py
@@ -4,7 +4,7 @@ import urllib.parse
 
 import httpx
 
-from ..constant import COMMON_HEADER, IOS_HEADER
+from ..constant import COMMON_HEADER, COMMON_TIMEOUT, IOS_HEADER
 from ..exception import ParseException
 from .data import ParseResult
 from .utils import get_redirect_url
@@ -39,7 +39,7 @@ class KuaishouParser:
         # /fw/long-video/ 返回结果不一样, 统一替换为 /fw/photo/ 请求
         location_url = location_url.replace("/fw/long-video/", "/fw/photo/")
 
-        async with httpx.AsyncClient(headers=self.v_headers) as client:
+        async with httpx.AsyncClient(headers=self.v_headers, timeout=COMMON_TIMEOUT) as client:
             response = await client.get(location_url)
             response.raise_for_status()
             response_text = response.text
@@ -113,7 +113,7 @@ class KuaishouParser:
         encoded_url = urllib.parse.quote(standard_url)
         api_url = self.api_url.format(encoded_url)
 
-        async with httpx.AsyncClient(headers=self.headers) as client:
+        async with httpx.AsyncClient(headers=self.headers, timeout=COMMON_TIMEOUT) as client:
             response = await client.get(api_url)
             if response.status_code != 200:
                 raise ParseException(f"解析 API 返回错误状态码: {response.status_code}")

--- a/src/nonebot_plugin_resolver2/parsers/weibo.py
+++ b/src/nonebot_plugin_resolver2/parsers/weibo.py
@@ -3,7 +3,7 @@ import re
 
 import httpx
 
-from ..constant import COMMON_HEADER
+from ..constant import COMMON_HEADER, COMMON_TIMEOUT
 from ..exception import ParseException
 from .data import ParseResult
 
@@ -40,7 +40,7 @@ class WeiBoParser:
             **COMMON_HEADER,
         }
         post_content = 'data={"Component_Play_Playinfo":{"oid":"' + fid + '"}}'
-        async with httpx.AsyncClient(headers=headers) as client:
+        async with httpx.AsyncClient(headers=headers, timeout=COMMON_TIMEOUT) as client:
             response = await client.post(req_url, content=post_content)
             response.raise_for_status()
             json_data = response.json()
@@ -75,7 +75,7 @@ class WeiBoParser:
         }
 
         # 请求数据
-        async with httpx.AsyncClient(headers=headers) as client:
+        async with httpx.AsyncClient(headers=headers, timeout=COMMON_TIMEOUT) as client:
             response = await client.get(f"https://m.weibo.cn/statuses/show?id={weibo_id}")
             if response.status_code != 200:
                 raise ParseException(f"获取数据失败 {response.status_code} {response.reason_phrase}")

--- a/src/nonebot_plugin_resolver2/parsers/xiaohongshu.py
+++ b/src/nonebot_plugin_resolver2/parsers/xiaohongshu.py
@@ -5,7 +5,7 @@ from urllib.parse import parse_qs, urlparse
 import httpx
 
 from ..config import rconfig
-from ..constant import COMMON_HEADER
+from ..constant import COMMON_HEADER, COMMON_TIMEOUT
 from ..exception import ParseException
 from .data import ParseResult
 from .utils import get_redirect_url
@@ -52,7 +52,7 @@ class XiaoHongShuParser:
 
         # 构造完整 URL
         url = f"https://www.xiaohongshu.com/explore/{xhs_id}?xsec_source={xsec_source}&xsec_token={xsec_token}"
-        async with httpx.AsyncClient(headers=self.headers) as client:
+        async with httpx.AsyncClient(headers=self.headers, timeout=COMMON_TIMEOUT) as client:
             response = await client.get(url)
             html = response.text
 

--- a/tests/test_douyin.py
+++ b/tests/test_douyin.py
@@ -134,10 +134,10 @@ async def test_douyin_slides():
 async def test_douyin_oversea():
     import httpx
 
-    from nonebot_plugin_resolver2.constant import IOS_HEADER
+    from nonebot_plugin_resolver2.constant import COMMON_TIMEOUT, IOS_HEADER
 
     url = "https://m.douyin.com/share/note/7484675353898667274"
-    async with httpx.AsyncClient(headers=IOS_HEADER) as client:
+    async with httpx.AsyncClient(headers=IOS_HEADER, timeout=COMMON_TIMEOUT) as client:
         response = await client.get(url)
         # headers
         # logger.debug("headers")

--- a/uv.lock
+++ b/uv.lock
@@ -757,7 +757,7 @@ wheels = [
 
 [[package]]
 name = "nonebot-plugin-resolver2"
-version = "1.10.0"
+version = "1.10.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary by Sourcery

Enhance CI pytest workflow by splitting bilibili tests into separate steps and enabling the kuaishou test job, and improve HTTP reliability in the Twitter matcher by adding a request timeout.

Enhancements:
- Add a 20-second timeout to the httpx.AsyncClient in the Twitter matcher to prevent hanging requests

CI:
- Split bilibili pytest into dedicated steps for read, live, audio/video, favlist, and video tests
- Uncomment and configure the kuaishou-test job to run a specific Kuaishou parse test